### PR TITLE
Change content-margin selector (exclude margin-block-*)

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ const createRuleData = (dataList) => {
 const selPropDisallowedList = [
 	[ { regex: text_selectors },
 		{ properties: [/float/], keywordId: "content-float" },
-		{ properties: [/margin(?!-top|-bottom)/], keywordId: "content-margin" },
+		{ properties: [/margin(?!-top|-bottom|-block)/], keywordId: "content-margin" },
 		{ properties: [/padding/], keywordId: "content-padding" },
 		{ properties: [/^width/, /^height/], keywordId: "selector-dimensions" } ],
 	[ { regex: component_selectors },


### PR DESCRIPTION
```
p {
    margin-block-start: 0;
    margin-block-end: var(--spacing-md);
}
```

is creating a false positive « Seuls les marges verticales sont appliquées aux balises de contenu. », but margin-block margins are vertical margins 🙂 So, adding "-block" in the exclusion list let us use margin-block when needed.