### PR TITLE
Fix broken urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This config adds a more detailed messaging system.
 
-For the complete documentation, see [ecss.info](https://ecss.info).
+For the complete documentation, see [ecss.info](https://ecss.info/en).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/efficientcss/stylelint-config-ecss/issues"
   },
-  "homepage": "https://ecss.info",
+  "homepage": "https://ecss.info/en",
   "peerDependencies": {
     "stylelint": "^16.0.0"
   },


### PR DESCRIPTION
https://ecss.info/ throws a 404

<img width="728" alt="imagen" src="https://github.com/user-attachments/assets/a09c132a-a23d-4630-b6a9-3ca8b7d2e37c">

